### PR TITLE
Fixed. No such module 'BRLMPrinterKit'.

### DIFF
--- a/RdlaboCapacitorBrotherprint.podspec
+++ b/RdlaboCapacitorBrotherprint.podspec
@@ -10,11 +10,17 @@ Pod::Spec.new do |s|
   s.homepage = package['repository']['url']
   s.author = package['author']
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
-  s.source_files = ['ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp,modulemap}']
+  s.source_files = ['ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}']
   s.ios.deployment_target  = '11.0'
   s.dependency 'Capacitor'
   s.dependency 'BRLMPrinterKit'
   s.swift_version = '5.1'
   # s.preserve_path = 'ios/Plugin/module.modulemap'
-  # s.module_map = 'ios/Plugin/module.modulemap'
+
+   s.preserve_path = 'ios/Plugin/module.modulemap'
+  #  s.module_map = 'ios/Plugin/module.modulemap'
+  
+  s.xcconfig = {
+  "SWIFT_INCLUDE_PATHS" => "$(PODS_TARGET_SRCROOT)/ios/Plugin/"
+  }
 end

--- a/RdlaboCapacitorBrotherprint.podspec
+++ b/RdlaboCapacitorBrotherprint.podspec
@@ -15,12 +15,9 @@ Pod::Spec.new do |s|
   s.dependency 'Capacitor'
   s.dependency 'BRLMPrinterKit'
   s.swift_version = '5.1'
-  # s.preserve_path = 'ios/Plugin/module.modulemap'
+  s.preserve_path = 'ios/Plugin/module.modulemap'
 
-   s.preserve_path = 'ios/Plugin/module.modulemap'
-  #  s.module_map = 'ios/Plugin/module.modulemap'
-  
-#   s.xcconfig = {
-#   "SWIFT_INCLUDE_PATHS" => "$(PODS_TARGET_SRCROOT)/ios/Plugin/"
-#   }
+  s.xcconfig = {
+    "SWIFT_INCLUDE_PATHS" => "$(PODS_TARGET_SRCROOT)/ios/Plugin/"
+  }
 end

--- a/RdlaboCapacitorBrotherprint.podspec
+++ b/RdlaboCapacitorBrotherprint.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
    s.preserve_path = 'ios/Plugin/module.modulemap'
   #  s.module_map = 'ios/Plugin/module.modulemap'
   
-  s.xcconfig = {
-  "SWIFT_INCLUDE_PATHS" => "$(PODS_TARGET_SRCROOT)/ios/Plugin/"
-  }
+#   s.xcconfig = {
+#   "SWIFT_INCLUDE_PATHS" => "$(PODS_TARGET_SRCROOT)/ios/Plugin/"
+#   }
 end

--- a/ios/Plugin/module.modulemap
+++ b/ios/Plugin/module.modulemap
@@ -1,9 +1,9 @@
 module BRLMPrinterKit {
-    header "../Pods/BRLMPrinterKit/BRLMPrinterKit/BRLMPrinterKit.framework/Headers/BRLMPrinterKit.h"
+    header "../../../BRLMPrinterKit/BRLMPrinterKit/BRLMPrinterKit.framework/Headers/BRLMPrinterKit.h"
     link "BRLMPrinterKit"
 }
 
 module BRPtouchPrinterKit {
-    header "../Pods/BRLMPrinterKit/BRLMPrinterKit/BRLMPrinterKit.framework/Headers/BRPtouchPrinterKit.h"
+    header "../../../BRLMPrinterKit/BRLMPrinterKit/BRLMPrinterKit.framework/Headers/BRPtouchPrinterKit.h"
     link "BRPtouchPrinterKit"
 }

--- a/ios/Plugin/module.modulemap
+++ b/ios/Plugin/module.modulemap
@@ -1,9 +1,9 @@
 module BRLMPrinterKit {
-    header "../../../BRLMPrinterKit/BRLMPrinterKit/BRLMPrinterKit.framework/Headers/BRLMPrinterKit.h"
+    header "../../../../../ios/App/Pods/BRLMPrinterKit/BRLMPrinterKit/BRLMPrinterKit.framework/Headers/BRLMPrinterKit.h"
     link "BRLMPrinterKit"
 }
 
 module BRPtouchPrinterKit {
-    header "../../../BRLMPrinterKit/BRLMPrinterKit/BRLMPrinterKit.framework/Headers/BRPtouchPrinterKit.h"
+    header "../../../../../ios/App/Pods/BRLMPrinterKit/BRLMPrinterKit/BRLMPrinterKit.framework/Headers/BRPtouchPrinterKit.h"
     link "BRPtouchPrinterKit"
 }


### PR DESCRIPTION
- CocoaPodsでRdlaboCapacitorBrotherprintが動作するように、
  RdlaboCapacitorBrotherprint.podspec,ios/Plugin/module.modulemap を変更。

- Capacitor の公式手順通りに作成したiOSアプリで利用可能。
Building your App - Capacitor https://capacitorjs.com/docs/basics/building-your-app

- もし異なるパスにする場合には、ios/Plugin/module.modulemap 中の相対パスをを修正する必要あり。