### PR TITLE
feat(): add is-port-available method

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ https://github.com/rdlabo-team/capacitor-brotherprint/blob/main/demo/src/app/hom
 
 * [`printImage(...)`](#printimage)
 * [`search(...)`](#search)
+* [`isPortAvailable(...)`](#isportavailable)
 * [`cancelSearchWiFiPrinter()`](#cancelsearchwifiprinter)
 * [`cancelSearchBluetoothPrinter()`](#cancelsearchbluetoothprinter)
 * [`addListener(BrotherPrintEventsEnum.onPrinterAvailable, ...)`](#addlistenerbrotherprinteventsenumonprinteravailable-)
@@ -312,6 +313,22 @@ Search for printers. If not found, it will return an empty array.(not error)
 | Param        | Type                                                          |
 | ------------ | ------------------------------------------------------------- |
 | **`option`** | <code><a href="#brlmsearchoption">BRLMSearchOption</a></code> |
+
+--------------------
+
+
+### isPortAvailable(...)
+
+```typescript
+isPortAvailable(option: BRLMChannelResult) => Promise<void>
+```
+
+If you have saved the last connected <a href="#brlmchannelresult">BRLMChannelResult</a>,
+you can use it to verify whether it is currently usable.
+
+| Param        | Type                                                            |
+| ------------ | --------------------------------------------------------------- |
+| **`option`** | <code><a href="#brlmchannelresult">BRLMChannelResult</a></code> |
 
 --------------------
 
@@ -426,7 +443,12 @@ Failed to print.
 
 #### BRLMPrintOptions
 
-<code>{ encodedImage: string; /** * Should use enum <a href="#brlmprintermodelname">BRLMPrinterModelName</a> */ modelName: <a href="#brlmprintermodelname">BRLMPrinterModelName</a>; } & <a href="#partial">Partial</a>&lt;<a href="#brlmchannelresult">BRLMChannelResult</a>&gt; & (<a href="#brlmprinterqlmodelsettings">BRLMPrinterQLModelSettings</a> | <a href="#brlmprintertdmodelsettings">BRLMPrinterTDModelSettings</a>)</code>
+<code>{ encodedImage: string; /** * Should use enum <a href="#brlmprintermodelname">BRLMPrinterModelName</a> */ modelName: <a href="#brlmprintermodelname">BRLMPrinterModelName</a>; } & <a href="#brlmprintchannelconnect">BRLMPrintChannelConnect</a> & (<a href="#brlmprinterqlmodelsettings">BRLMPrinterQLModelSettings</a> | <a href="#brlmprintertdmodelsettings">BRLMPrinterTDModelSettings</a>)</code>
+
+
+#### BRLMPrintChannelConnect
+
+<code><a href="#partial">Partial</a>&lt;<a href="#brlmchannelresult">BRLMChannelResult</a>&gt; & <a href="#pick">Pick</a>&lt;<a href="#brlmchannelresult">BRLMChannelResult</a>, 'channelInfo'&gt;</code>
 
 
 #### Partial
@@ -439,6 +461,13 @@ Make all properties in T optional
 #### BRLMChannelResult
 
 <code>{ port: <a href="#brlmprinterport">BRLMPrinterPort</a>; modelName: string; serialNumber: string; macAddress: string; nodeName: string; location: string; /** * This need to connect to the printer. * wifi: IP Address * bluetooth: macAddress * bluetoothLowEnergy: modelName for bluetoothLowEnergy */ channelInfo: string; }</code>
+
+
+#### Pick
+
+From T, pick a set of properties whose keys are in the union K
+
+<code>{ [P in K]: T[P]; }</code>
 
 
 #### BRLMPrinterQLModelSettings

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Search for printers. If not found, it will return an empty array.(not error)
 ### isPortAvailable(...)
 
 ```typescript
-isPortAvailable(option: BRLMChannelResult) => Promise<void>
+isPortAvailable(option: BRLMChannelResult) => Promise<isPortAvailableResult>
 ```
 
 If you have saved the last connected <a href="#brlmchannelresult">BRLMChannelResult</a>,
@@ -329,6 +329,8 @@ you can use it to verify whether it is currently usable.
 | Param        | Type                                                            |
 | ------------ | --------------------------------------------------------------- |
 | **`option`** | <code><a href="#brlmchannelresult">BRLMChannelResult</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#isportavailableresult">isPortAvailableResult</a>&gt;</code>
 
 --------------------
 
@@ -443,12 +445,7 @@ Failed to print.
 
 #### BRLMPrintOptions
 
-<code>{ encodedImage: string; /** * Should use enum <a href="#brlmprintermodelname">BRLMPrinterModelName</a> */ modelName: <a href="#brlmprintermodelname">BRLMPrinterModelName</a>; } & <a href="#brlmprintchannelconnect">BRLMPrintChannelConnect</a> & (<a href="#brlmprinterqlmodelsettings">BRLMPrinterQLModelSettings</a> | <a href="#brlmprintertdmodelsettings">BRLMPrinterTDModelSettings</a>)</code>
-
-
-#### BRLMPrintChannelConnect
-
-<code><a href="#partial">Partial</a>&lt;<a href="#brlmchannelresult">BRLMChannelResult</a>&gt; & <a href="#pick">Pick</a>&lt;<a href="#brlmchannelresult">BRLMChannelResult</a>, 'channelInfo'&gt;</code>
+<code>{ encodedImage: string; /** * Should use enum <a href="#brlmprintermodelname">BRLMPrinterModelName</a> */ modelName: <a href="#brlmprintermodelname">BRLMPrinterModelName</a>; } & <a href="#partial">Partial</a>&lt;<a href="#brlmchannelresult">BRLMChannelResult</a>&gt; & (<a href="#brlmprinterqlmodelsettings">BRLMPrinterQLModelSettings</a> | <a href="#brlmprintertdmodelsettings">BRLMPrinterTDModelSettings</a>)</code>
 
 
 #### Partial
@@ -461,13 +458,6 @@ Make all properties in T optional
 #### BRLMChannelResult
 
 <code>{ port: <a href="#brlmprinterport">BRLMPrinterPort</a>; modelName: string; serialNumber: string; macAddress: string; nodeName: string; location: string; /** * This need to connect to the printer. * wifi: IP Address * bluetooth: macAddress * bluetoothLowEnergy: modelName for bluetoothLowEnergy */ channelInfo: string; }</code>
-
-
-#### Pick
-
-From T, pick a set of properties whose keys are in the union K
-
-<code>{ [P in K]: T[P]; }</code>
 
 
 #### BRLMPrinterQLModelSettings
@@ -510,6 +500,11 @@ These are optional. If these are not set, default values are assigned by the pri
 #### BRLMSearchOption
 
 <code>{ /** * 'usb' is android only, and now developing. */ port: <a href="#brlmprinterport">BRLMPrinterPort</a>; /** * searchDuration is the time to end search for devices. * default is 15 seconds. * use only port is 'wifi' or 'bluetoothLowEnergy'. */ searchDuration: number; }</code>
+
+
+#### isPortAvailableResult
+
+<code>{ result: boolean; }</code>
 
 
 #### ErrorInfo

--- a/demo/src/app/home/home.page.html
+++ b/demo/src/app/home/home.page.html
@@ -176,7 +176,7 @@
         <ion-item><ion-label>nodeName</ion-label><ion-text>{{channel.nodeName}}</ion-text></ion-item>
         <ion-item><ion-label>location</ion-label><ion-text>{{channel.location}}</ion-text></ion-item>
         <ion-item><ion-label>channelInfo</ion-label><ion-text>{{channel.channelInfo}}</ion-text></ion-item>
-        <ion-item button="true" color="secondary" (click)="isPortAvailable(channel)"
+        <ion-item button="true" color="warning" (click)="isPortAvailable(channel)"
         ><ion-label>Validate channel</ion-label></ion-item
         >
         <ion-item button="true" color="primary" (click)="print(channel)"

--- a/demo/src/app/home/home.page.ts
+++ b/demo/src/app/home/home.page.ts
@@ -127,6 +127,7 @@ export class HomePage implements OnInit, OnDestroy {
     const toast = await this.toastCtrl.create({
       color: result ? 'success' : 'warning',
       message: result ? 'Ready to print' : 'Failed to connect',
+      duration: 400,
     });
     await toast.present();
   }

--- a/demo/src/app/home/home.page.ts
+++ b/demo/src/app/home/home.page.ts
@@ -9,12 +9,11 @@ import {
   IonItemGroup,
   IonLabel,
   IonText,
-  IonRadioGroup,
-  IonRadio,
   IonSelect,
   IonSelectOption,
   IonInput,
   Platform,
+  ToastController,
 } from '@ionic/angular/standalone';
 import {
   BRLMPrinterCustomPaperType,
@@ -34,7 +33,7 @@ import {
   BRLMPrinterPrintQuality,
   BRLMPrinterScaleMode,
   BRLMPrinterVerticalAlignment,
-  ErrorInfo,
+  isPortAvailableResult,
 } from '../../../../src';
 import { FormsModule } from '@angular/forms';
 import { printData } from '../print-data';
@@ -54,8 +53,6 @@ import { setPlatformOptions } from 'ionicons/components';
     IonItemGroup,
     IonLabel,
     IonText,
-    IonRadioGroup,
-    IonRadio,
     FormsModule,
     IonSelect,
     IonSelectOption,
@@ -88,6 +85,7 @@ export class HomePage implements OnInit, OnDestroy {
   readonly printers = signal<BRLMChannelResult[]>([]);
   readonly base64: string = printData();
   readonly platform = inject(Platform);
+  readonly toastCtrl = inject(ToastController);
 
   async ngOnInit() {
     this.listenerHandlers.push(
@@ -122,6 +120,15 @@ export class HomePage implements OnInit, OnDestroy {
       port,
       searchDuration: 15, // seconds
     });
+  }
+
+  async isPortAvailable(channel: BRLMChannelResult) {
+    const { result } = await BrotherPrint.isPortAvailable(channel);
+    const toast = await this.toastCtrl.create({
+      color: result ? 'success' : 'warning',
+      message: result ? 'Ready to print' : 'Failed to connect',
+    });
+    await toast.present();
   }
 
   print(channel: BRLMChannelResult) {

--- a/ios/Sources/BrotherPrintPlugin/BrotherPrintPlugin.swift
+++ b/ios/Sources/BrotherPrintPlugin/BrotherPrintPlugin.swift
@@ -12,10 +12,11 @@ public class BrotherPrintPlugin: CAPPlugin, CAPBridgedPlugin {
     public let jsName = "BrotherPrint"
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "printImage", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "isPortAvailable", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "search", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "cancelSearchWiFiPrinter", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "cancelSearchBluetoothPrinter", returnType: CAPPluginReturnPromise),
-    ] 
+        CAPPluginMethod(name: "cancelSearchBluetoothPrinter", returnType: CAPPluginReturnPromise)
+    ]
     private var cancelRoutineWiFi: (() -> Void)?
     private var cancelRoutineBluetooth: (() -> Void)?
 
@@ -130,6 +131,35 @@ public class BrotherPrintPlugin: CAPPlugin, CAPBridgedPlugin {
 
             self.notifyListeners(BrotherPrinterEvent.onPrint.rawValue, data: [:])
             call.resolve()
+        }
+    }
+    
+    @objc func isPortAvailable(_ call: CAPPluginCall) {
+        let port: String = call.getString("port", "wifi")
+        let channelInfo: String = call.getString("channelInfo", "")
+        
+        DispatchQueue.main.async {
+            var channel: BRLMChannel
+            switch port {
+            case "wifi":
+                channel = BRLMChannel(wifiIPAddress: channelInfo)
+            case "bluetooth":
+                channel = BRLMChannel(bluetoothSerialNumber: channelInfo)
+            case "bluetoothLowEnergy":
+                channel = BRLMChannel(bleLocalName: channelInfo)
+            default:
+                call.reject("Error - connection is not found.")
+                return
+            }
+            let generateResult = BRLMPrinterDriverGenerator.open(channel)
+            
+            guard generateResult.error.code == BRLMOpenChannelErrorCode.noError,
+                  let printerDriver = generateResult.driver else {
+                call.resolve(["result": false]);
+                return;
+            }
+            printerDriver.closeChannel()
+            call.resolve(["result": true]);
         }
     }
 

--- a/ios/Sources/BrotherPrintPlugin/BrotherPrintPlugin.swift
+++ b/ios/Sources/BrotherPrintPlugin/BrotherPrintPlugin.swift
@@ -133,11 +133,11 @@ public class BrotherPrintPlugin: CAPPlugin, CAPBridgedPlugin {
             call.resolve()
         }
     }
-    
+
     @objc func isPortAvailable(_ call: CAPPluginCall) {
         let port: String = call.getString("port", "wifi")
         let channelInfo: String = call.getString("channelInfo", "")
-        
+
         DispatchQueue.main.async {
             var channel: BRLMChannel
             switch port {
@@ -152,14 +152,14 @@ public class BrotherPrintPlugin: CAPPlugin, CAPBridgedPlugin {
                 return
             }
             let generateResult = BRLMPrinterDriverGenerator.open(channel)
-            
+
             guard generateResult.error.code == BRLMOpenChannelErrorCode.noError,
                   let printerDriver = generateResult.driver else {
-                call.resolve(["result": false]);
-                return;
+                call.resolve(["result": false])
+                return
             }
             printerDriver.closeChannel()
-            call.resolve(["result": true]);
+            call.resolve(["result": true])
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^15.5.1",
         "np": "^10.0.5",
-        "prettier": "^3.6.2",
+        "prettier": "^3.8.1",
         "prettier-plugin-java": "^2.7.7",
         "rimraf": "^6.1.0",
         "rollup": "^4.53.2",
@@ -29,7 +29,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
@@ -6351,9 +6351,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^15.5.1",
     "np": "^10.0.5",
-    "prettier": "^3.6.2",
+    "prettier": "^3.8.1",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
     "rollup": "^4.53.2",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,7 +1,13 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 
 import type { BrotherPrintEventsEnum } from './events.enum';
-import type { BRLMChannelResult, BRLMPrintOptions, BRLMSearchOption, ErrorInfo } from './interfaces';
+import type {
+  BRLMChannelResult,
+  BRLMPrintOptions,
+  BRLMSearchOption,
+  ErrorInfo,
+  isPortAvailableResult,
+} from './interfaces';
 
 export interface BrotherPrintPlugin {
   printImage(options: BRLMPrintOptions): Promise<void>;
@@ -10,6 +16,12 @@ export interface BrotherPrintPlugin {
    * Search for printers. If not found, it will return an empty array.(not error)
    */
   search(option: BRLMSearchOption): Promise<void>;
+
+  /**
+   * If you have saved the last connected BRLMChannelResult,
+   * you can use it to verify whether it is currently usable.
+   */
+  isPortAvailable(option: BRLMChannelResult): Promise<isPortAvailableResult>;
 
   /**
    * Basically, it times out, so there is no need to use it. Use it when you want to run multiple connectType searches at the same time and time out any of them manually.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -44,6 +44,10 @@ export type BRLMPrintOptions = {
 } & Partial<BRLMChannelResult> &
   (BRLMPrinterQLModelSettings | BRLMPrinterTDModelSettings);
 
+export type isPortAvailableResult = {
+  result: boolean;
+};
+
 export type BRLMPrinterTDModelSettings = {
   /**
    * Should use enum BRKMPrinterCustomPaperType

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,11 +1,17 @@
 import { WebPlugin } from '@capacitor/core';
 
 import type { BrotherPrintPlugin } from './definitions';
-import type { BRLMPrintOptions, BRLMSearchOption } from './interfaces';
+import type { BRLMChannelResult, BRLMPrintOptions, BRLMSearchOption, isPortAvailableResult } from './interfaces';
 
 export class BrotherPrintWeb extends WebPlugin implements BrotherPrintPlugin {
   async printImage(options: BRLMPrintOptions): Promise<void> {
     console.log('printImage', options);
+  }
+  async isPortAvailable(options: BRLMChannelResult): Promise<isPortAvailableResult> {
+    console.log('isPortAvailable', options);
+    return {
+      result: false,
+    };
   }
   async search(options: BRLMSearchOption): Promise<void> {
     console.log('search', options);


### PR DESCRIPTION
Previously, users had to perform a search to check if a printer was available because communication and printing were done simultaneously. Now, users with a fixed printer no longer need to perform time-consuming searches.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rdlabo-team/capacitor-brotherprint/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
