### PR TITLE
chore: set "private": false in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@rdlabo/capacitor-brotherprint",
+  "private": false,
   "version": "8.1.1",
   "description": "Capacitor plugin for Brother Print SDK",
   "main": "dist/plugin.cjs.js",


### PR DESCRIPTION
Set `"private": false` in `package.json` to reflect that this repository is **public** on GitHub.